### PR TITLE
Prevent error upon running nlcovidstats.py

### DIFF
--- a/nlcovidstats.py
+++ b/nlcovidstats.py
@@ -11,6 +11,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import urllib
+import urllib.request
 from pathlib import Path
 import time
 import locale


### PR DESCRIPTION
Without this PR running ``python3 nlcovidstats.py`` would yield the following error:
```
Getting new file ...
Traceback (most recent call last):
  File "nlcovidstats.py", line 517, in <module>
    df = load_cumulative_cases()
  File "nlcovidstats.py", line 122, in load_cumulative_cases
    update_cum_cases_csv()
  File "nlcovidstats.py", line 110, in update_cum_cases_csv
    with urllib.request.urlopen(url) as response:
AttributeError: module 'urllib' has no attribute 'request'
```