### PR TITLE
Convert timestamps to seconds

### DIFF
--- a/nlcovidstats.py
+++ b/nlcovidstats.py
@@ -657,9 +657,10 @@ def estimate_Rt_df(r, delay=9, Tc=4.0):
         fD, fdD, _ = construct_Dfunc(delay)
 
         # note: timestamps in nanoseconds, rates in 'per day' units.
-        day_ns = 86400e9
-        tr = r.index.astype(int)
-        ti = tr - fD(tr) * day_ns
+        # convert timestamps to seconds.
+        day_s = 86400
+        tr = r.index.astype(int) / int(1e9) 
+        ti = tr - fD(tr) * day_s
         ri = r.to_numpy() / (1 - fdD(tr))
 
         # now get log-derivative the same way as above
@@ -670,7 +671,7 @@ def estimate_Rt_df(r, delay=9, Tc=4.0):
         # build series with timestamp index
         Rt_series = pd.Series(
             data=Rt, name='Rt',
-            index=pd.to_datetime(ti[1:-1].astype(int))
+            index=pd.to_datetime(ti[1:-1].astype(int), unit='s')
         )
         Rdf = pd.DataFrame(dict(Rt=Rt_series))
         Rdf['delay'] = fD(tr[1:-1])


### PR DESCRIPTION
`pd.to_datetime` fails using nanosecond timestamps in the most recent pandas (pd 1.2.4/np 1.19.5/win64)

I tried recreating your plots (anaconda win64, python 3.9, recent pandas/numpy from conda-forge)
In the R vs cases plot all timestamps where mangled to 1970. This turns out to be `pd.to_datetime` [L673](https://github.com/han-kwang/covid19/blob/master/nlcovidstats.py#L673) failing on converting the nanosecond timestamp. (Even when forcing `unit='ns'`) 

This converts the timestamp to seconds, and forces `unit='s'` for clarity.

(I only tested ` plot_R_from_daily_cases.py`)